### PR TITLE
Enhanced : Enhanced the getServiceData method.

### DIFF
--- a/src/Exception/ActionException.php
+++ b/src/Exception/ActionException.php
@@ -117,6 +117,11 @@ class ActionException extends AnserException
         return new self("尚未定義 {$serviceName} 服務進服務列表內，請檢查服務的 serviceName 是否正確。");
     }
 
+    public static function forServiceDataCallbackTypeError(string $serviceName): ActionException
+    {
+        return new self("Action {$serviceName} 定義的回呼函數回傳型別錯誤，請檢查回傳型別是否為 \SDPMlab\Anser\Service\ServiceSettings 或 null。");
+    }
+
     /**
      * 取得發生錯誤的 Restponse 實體
      *


### PR DESCRIPTION
**Description**
1. Enhance the getServiceData method to be compatible with external callable function.
2. Append the `serviceDataHandlerCallback` property to store the callable.
3. The `setServiceDataHandler` be use to setup callable.
4. Append the call `serviceDataHandlerCallback` step on `getServiceData` method.
5. Add exception with name `forServiceDataCallbackTypeError` to `ActionException`, this exception throws if the `callable` retrun type isn't `ServiceSetting`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide
