### PR TITLE
Dev : Append the JSON-RPC method into `Action` logic.

### DIFF
--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -231,13 +231,13 @@ var_dump($taichungService->getAction2()->do()->getMeaningData());
 
 ### HTTP JSON RPC
 
-你可以在 `Action` 物件中，透過使用 `setRpcQuery()` 方法將欲呼叫的 `method`、`params`、`id` 傳入，即可利用RPC進行 HTTP 連線。
+你可以在 `Action` 物件中，透過使用 `setRpcQuery()` 方法將欲呼叫的 `method`、`params`、`id` 傳入，即可進行RPC連線。
 
 啟用 `setRpcQuery()` 方法後，`Action` 的 HTTP 呼叫動詞將會自動轉為 `POST`。 
 
-透過 doneHandler 的設定，你能夠設定連線成功時的執行邏輯，並透過 setMeaningData 將所需的資料暫存在 Action 實體中。
+透過 `doneHandler` 的設定，你能夠設定連線成功時的執行邏輯，並透過 `setMeaningData` 將所需的資料暫存在 `Action` 實體中。
 
-在此你必須透過 `ServiceList` 提供的 `getRpcClient()` 進行RPC資料解包，搭配 `decode()` 將 `response Body` 傳入，最終將可使用 `getValue` 取得資料。 
+在此你必須透過 `ServiceList` 提供的 `getRpcClient()` 進行RPC資料解析，搭配 `decode()` 方法將 `response Body` 傳入，最終使用 `getValue` 取得資料。 
 
 ```php
 require './vendor/autoload.php';
@@ -265,7 +265,7 @@ var_dump($data);
 ```
 
 ### HTTP JSON RPC 錯誤處理
-你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時，如 : Parse error、Invalid Request、Method not found、Invalid params、Internal error、Server error 的處理邏輯。
+你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時，如 : `Parse error`、`Invalid Request`、`Method not found`、`Invalid params`、`Internal error`、`Server error` 的處理邏輯。
 
 ```php
 require './vendor/autoload.php';

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -232,8 +232,11 @@ var_dump($taichungService->getAction2()->do()->getMeaningData());
 ### HTTP JSON RPC
 
 你可以在 `Action` 物件中，透過使用 `setRpcQuery()` 方法將欲呼叫的 `method`、`params`、`id` 傳入，即可利用RPC進行 HTTP 連線。
+
 啟用 `setRpcQuery()` 方法後，`Action` 的 HTTP 呼叫動詞將會自動轉為 `POST`。 
+
 透過 doneHandler 的設定，你能夠設定連線成功時的執行邏輯，並透過 setMeaningData 將所需的資料暫存在 Action 實體中。
+
 在此你必須透過 `ServiceList` 提供的 `getRpcClient()` 進行RPC資料解包，搭配 `decode()` 將 `response Body` 傳入，最終將可使用 `getValue` 取得資料。 
 
 ```php

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -228,3 +228,98 @@ var_dump($taichungService->getAction1()->do()->getMeaningData());
 var_dump($taichungService->getAction2()->do()->getMeaningData());
 var_dump($taichungService->getAction2()->do()->getMeaningData());
 ```
+
+### HTTP JSON RPC
+
+你可以在 `Action` 物件中，透過使用 `setRpcQuery()` 方法將欲呼叫的 `method`、`params`、`id` 傳入，即可利用RPC進行 HTTP 連線。
+啟用 `setRpcQuery()` 方法後，`Action` 的 HTTP 呼叫動詞將會自動轉為 `POST`。 
+透過 doneHandler 的設定，你能夠設定連線成功時的執行邏輯，並透過 setMeaningData 將所需的資料暫存在 Action 實體中。
+在此你必須透過 `ServiceList` 提供的 `getRpcClient()` 進行RPC資料解包，搭配 `decode()` 將 `response Body` 傳入，最終將可使用 `getValue` 取得資料。 
+
+```php
+require './vendor/autoload.php';
+use SDPMlab\Anser\Service\Action;
+use Psr\Http\Message\ResponseInterface;
+use SDPMlab\Anser\Service\ServiceList;
+
+$id = 1;
+$action = (new Action(
+    'http://myRpcServer.com',
+    "POST",
+    "/"
+))
+->setRpcQuery("/myRpcMethod", [], $id)
+->doneHandler(static function(
+    ResponseInterface $response,
+    Action $runtimeAction
+) {
+    $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
+    $runtimeAction->setMeaningData($body);
+});
+
+$data = $action->do()->getMeaningData();
+var_dump($data);
+```
+
+### HTTP JSON RPC 錯誤處理
+你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時，如 : Parse error、Invalid Request、Method not found、Invalid params、Internal error、Server error 的處理邏輯。
+
+```php
+require './vendor/autoload.php';
+use SDPMlab\Anser\Service\Action;
+use Psr\Http\Message\ResponseInterface;
+use SDPMlab\Anser\Service\ServiceList;
+
+$id = 1;
+$action = (new Action(
+    'http://myRpcServer.com',
+    "POST",
+    "/"
+))
+->setRpcQuery("/myRpcMethod", [], $id)
+->doneHandler(static function(
+    ResponseInterface $response,
+    Action $runtimeAction
+) {
+    $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
+    $runtimeAction->setMeaningData($body);
+})
+->failHandler(function (
+    ActionException $e
+){
+    if ($e->isRpcMethodError()) {
+        $e->getAction()->setMeaningData([
+            "code" => 404,
+            "msg" => $e->getRpcMsg()
+        ]);
+    }else if($e->isRpcInvalidParams()){
+        $e->getAction()->setMeaningData([
+            "code" => 500,
+            "msg" => $e->getRpcMsg()
+        ]);    
+    }else if($e->isRpcInvalidRequest()){
+        $e->getAction()->setMeaningData([
+            "code" => 400,
+            "msg" => $e->getRpcMsg()
+        ]);    
+    }else if($e->isRpcParseError()){
+        $e->getAction()->setMeaningData([
+            "code" => 500,
+            "msg" => $e->getRpcMsg()
+        ]);    
+    }else if($e->isRpcInternalError()){
+        $e->getAction()->setMeaningData([
+            "code" => 500,
+            "msg" => $e->getRpcMsg()
+        ]);    
+    }else if($e->isRpcInternalServerError()){
+        $e->getAction()->setMeaningData([
+            "code" => 500,
+            "msg" => $e->getRpcMsg()
+        ]);    
+    }
+});
+
+$data = $action->do()->getMeaningData();
+var_dump($data);
+```

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -265,61 +265,123 @@ var_dump($data);
 ```
 
 ### HTTP JSON RPC 錯誤處理
-你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時的處理邏輯，如 : `Parse error`、`Invalid Request`、`Method not found`、`Invalid params`、`Internal error`、`Server error` 。
+你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時的處理邏輯，如 : `Parse error`、`Invalid Request`、`Method not found`、`Invalid params`、`Internal error`、`Server error` [參閱 JSON-RPC](https://www.jsonrpc.org/ "參閱 JSON-RPC")。
+
+你也可以使用 `Action` 的 HTTP連線錯誤處理搭配 `RPC` 錯誤處理。
 
 ```php
+<?php
 require './vendor/autoload.php';
-use SDPMlab\Anser\Service\Action;
-use Psr\Http\Message\ResponseInterface;
-use SDPMlab\Anser\Service\ServiceList;
 
-$id = 1;
+use \SDPMlab\Anser\Service\Action;
+use \Psr\Http\Message\ResponseInterface;
+use \SDPMlab\Anser\Exception\ActionException;
+
 $action = (new Action(
-    'http://myRpcServer.com',
-    "POST",
-    "/"
-))
-->setRpcQuery("/myRpcMethod", [], $id)
-->doneHandler(static function(
+    "https://error.endpoint",
+    "GET",
+    "/dfgdfg"
+))->doneHandler(function (
     ResponseInterface $response,
     Action $runtimeAction
 ) {
     $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
     $runtimeAction->setMeaningData($body);
-})
-->failHandler(function (
+})->failHandler(function (
     ActionException $e
-){
-    if ($e->isRpcMethodError()) {
+) {
+    if($e->isClientError()){
+        if ($e->isRpcMethodError()) {
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);
+        }else if($e->isRpcInvalidParams()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInvalidRequest()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcParseError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInternalError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInternalServerError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "client error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }
+    }else if ($e->isServerError()){
+        if ($e->isRpcMethodError()) {
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);
+        }else if($e->isRpcInvalidParams()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInvalidRequest()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcParseError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInternalError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }else if($e->isRpcInternalServerError()){
+            $e->getAction()->setMeaningData([
+                "code" => $e->getStatusCode(),
+                "msg" => "server error",
+                "rpcCode" => $e->getRpcCode(),
+                "rpcMsg" => $e->getRpcMsg(),
+            ]);    
+        }
+    }else if($e->isConnectError()){
         $e->getAction()->setMeaningData([
-            "code" => 404,
-            "msg" => $e->getRpcMsg()
+            "msg" => $e->getMessage()
         ]);
-    }else if($e->isRpcInvalidParams()){
-        $e->getAction()->setMeaningData([
-            "code" => 500,
-            "msg" => $e->getRpcMsg()
-        ]);    
-    }else if($e->isRpcInvalidRequest()){
-        $e->getAction()->setMeaningData([
-            "code" => 400,
-            "msg" => $e->getRpcMsg()
-        ]);    
-    }else if($e->isRpcParseError()){
-        $e->getAction()->setMeaningData([
-            "code" => 500,
-            "msg" => $e->getRpcMsg()
-        ]);    
-    }else if($e->isRpcInternalError()){
-        $e->getAction()->setMeaningData([
-            "code" => 500,
-            "msg" => $e->getRpcMsg()
-        ]);    
-    }else if($e->isRpcInternalServerError()){
-        $e->getAction()->setMeaningData([
-            "code" => 500,
-            "msg" => $e->getRpcMsg()
-        ]);    
     }
 });
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -265,7 +265,7 @@ var_dump($data);
 ```
 
 ### HTTP JSON RPC 錯誤處理
-你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時，如 : `Parse error`、`Invalid Request`、`Method not found`、`Invalid params`、`Internal error`、`Server error` 的處理邏輯。
+你將可以透過設定 `failHandler` 回呼函數，指揮 `Action` 在遇到RPC錯誤時的處理邏輯，如 : `Parse error`、`Invalid Request`、`Method not found`、`Invalid params`、`Internal error`、`Server error` 。
 
 ```php
 require './vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php" : "^7.4||^8.0",
         "psr/http-message": "^1.0",
-	    "guzzlehttp/guzzle": "^7.0"
+	    "guzzlehttp/guzzle": "^7.0",
+        "datto/json-rpc": "^6.1"
     },
     "autoload": {
 		"psr-4": {

--- a/develop/app/Config/Routes.php
+++ b/develop/app/Config/Routes.php
@@ -58,6 +58,10 @@ $routes->group(
         //Fail APIs
         $routes->get('fail','Fail::awayls429');
         $routes->get('fail/(:num)','Fail::awayls500/$1');
+
+        //Rpc APIs
+        $routes->get('doSingleAction','Rpc::doSingleAction');
+        $routes->get('doConcurrentAction','Rpc::doConcurrentAction');
     }
 );
 

--- a/develop/app/Config/Routes.php
+++ b/develop/app/Config/Routes.php
@@ -64,7 +64,8 @@ $routes->group(
         $routes->get('doConcurrentAction','Rpc::doConcurrentAction');
         $routes->get('doNativeAction','Rpc::doNativeAction');
         $routes->post('rpcServer','Rpc::rpcServer');
-        $routes->post('errorRpcServer','Rpc::errorRpcServer');
+        $routes->post('error429RpcServer','Rpc::error429RpcServer');
+        $routes->post('error500RpcServer','Rpc::error500RpcServer');
     }
 );
 

--- a/develop/app/Config/Routes.php
+++ b/develop/app/Config/Routes.php
@@ -62,6 +62,8 @@ $routes->group(
         //Rpc APIs
         $routes->get('doSingleAction','Rpc::doSingleAction');
         $routes->get('doConcurrentAction','Rpc::doConcurrentAction');
+        $routes->get('doNativeAction','Rpc::doNativeAction');
+        
     }
 );
 

--- a/develop/app/Config/Routes.php
+++ b/develop/app/Config/Routes.php
@@ -63,7 +63,8 @@ $routes->group(
         $routes->get('doSingleAction','Rpc::doSingleAction');
         $routes->get('doConcurrentAction','Rpc::doConcurrentAction');
         $routes->get('doNativeAction','Rpc::doNativeAction');
-        
+        $routes->post('rpcServer','Rpc::rpcServer');
+        $routes->post('errorRpcServer','Rpc::errorRpcServer');
     }
 );
 

--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -45,7 +45,7 @@ class Rpc extends BaseController
     public function doConcurrentAction()
     {
         $action = (new Action(
-            "http://140.127.74.161:9601",
+            env('serviceAddress'),
             "GET",
             "/"
         ))
@@ -100,6 +100,25 @@ class Rpc extends BaseController
             "action1" => $action1,
         ])->send();
         $data = ($concurrent->getActionsMeaningData());
+        return $this->response->setStatusCode(200)->setJSON($data);
+    }
+
+    public function doNativeAction()
+    {
+        $action = (new Action(
+            "https://jsonplaceholder.typicode.com",
+            "GET",
+            "/todos/1"
+        ))->doneHandler(function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ){
+            $body = $response->getBody()->getContents();
+            $data = json_decode($body, true);
+            $runtimeAction->setMeaningData($data);
+        });
+        
+        $data = $action->do()->getMeaningData();
         return $this->response->setStatusCode(200)->setJSON($data);
     }
 }

--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -3,13 +3,28 @@ namespace App\Controllers\V1;
 use App\Controllers\BaseController;
 use SDPMlab\Anser\Service\Action;
 use Psr\Http\Message\ResponseInterface;
-use CodeIgniter\HTTP\RequestTrait;
+use CodeIgniter\API\ResponseTrait;
 use SDPMlab\Anser\Exception\ActionException;
 use \SDPMlab\Anser\Service\ConcurrentAction;
 use SDPMlab\Anser\Service\ServiceList;
+
 class Rpc extends BaseController
 {
-    use RequestTrait;
+    use ResponseTrait;
+
+    public function rpcServer()
+    {
+        $data = $this->request->getBody();
+        $server = new \Datto\JsonRpc\Server(new \App\Controllers\V1\RpcApi());
+        $reply = $server->reply($data);
+        return $this->response->setStatusCode(200)->setJSON($reply);
+    }
+
+    public function errorRpcServer()
+    {
+        $reply = '{"jsonrpc": "2.0", "method"';
+        return $this->response->setStatusCode(200)->setJSON($reply);
+    }
 
     public function doSingleAction()
     {
@@ -106,9 +121,9 @@ class Rpc extends BaseController
     public function doNativeAction()
     {
         $action = (new Action(
-            "https://jsonplaceholder.typicode.com",
+            "http://localhost:8080",
             "GET",
-            "/todos/1"
+            "/api/v1/user"
         ))->doneHandler(function(
             ResponseInterface $response,
             Action $runtimeAction

--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -1,0 +1,107 @@
+<?php 
+namespace App\Controllers\V1;
+use App\Controllers\BaseController;
+use SDPMlab\Anser\Service\Action;
+use Psr\Http\Message\ResponseInterface;
+use CodeIgniter\HTTP\RequestTrait;
+use SDPMlab\Anser\Exception\ActionException;
+use \SDPMlab\Anser\Service\ConcurrentAction;
+use SDPMlab\Anser\Service\ServiceList;
+class Rpc extends BaseController
+{
+    use RequestTrait;
+
+    public function doSingleAction()
+    {
+        $action = (new Action(
+            env('serviceAddress'),
+            "GET",
+            "/"
+        ))
+        ->setRpcQuery("/producth/index",[])
+        ->doneHandler(static function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ) {
+
+            $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
+            $runtimeAction->setMeaningData($body);
+        })
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcMethodError()) {
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "msg" => $e->getRpcCode()
+                ]);
+            }
+        });
+
+        $data = $action->do()->getMeaningData();
+        return $this->response->setStatusCode(200)->setJSON($data);
+    }   
+
+    public function doConcurrentAction()
+    {
+        $action = (new Action(
+            "http://140.127.74.161:9601",
+            "GET",
+            "/"
+        ))
+        ->setRpcQuery("/producth/index",[])
+        ->doneHandler(static function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ) {
+            $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
+            $runtimeAction->setMeaningData($body);
+
+        })
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcMethodError()) {
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "msg" => $e->getRpcCode()
+                ]);
+            }
+        });
+
+        $action1 = (new Action(
+            env('serviceAddress'),
+            "POST",
+            "/"
+        ))
+        ->setRpcQuery("/producth/index",[])
+        ->doneHandler(static function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ) {
+            $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
+            $runtimeAction->setMeaningData($body);
+
+        })
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcMethodError()) {
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "msg" => $e->getRpcCode()
+                ]);
+            }
+        });
+
+        $concurrent = new ConcurrentAction();
+        $concurrent->setActions([
+            "action0" => $action,
+            "action1" => $action1,
+        ])->send();
+        $data = ($concurrent->getActionsMeaningData());
+        return $this->response->setStatusCode(200)->setJSON($data);
+    }
+}
+
+?>

--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -20,10 +20,20 @@ class Rpc extends BaseController
         return $this->response->setStatusCode(200)->setJSON($reply);
     }
 
-    public function errorRpcServer()
+    public function error429RpcServer()
     {
-        $reply = '{"jsonrpc": "2.0", "method"';
-        return $this->response->setStatusCode(200)->setJSON($reply);
+        $data = $this->request->getBody();
+        $server = new \Datto\JsonRpc\Server(new \App\Controllers\V1\RpcApi());
+        $reply = $server->reply($data);
+        return $this->response->setStatusCode(429)->setJSON($reply);
+    }
+
+    public function error500RpcServer()
+    {
+        $data = $this->request->getBody();
+        $server = new \Datto\JsonRpc\Server(new \App\Controllers\V1\RpcApi());
+        $reply = $server->reply($data);
+        return $this->response->setStatusCode(500)->setJSON($reply);
     }
 
     public function doSingleAction()
@@ -48,7 +58,11 @@ class Rpc extends BaseController
             if ($e->isRpcMethodError()) {
                 $e->getAction()->setMeaningData([
                     "code" => 400,
-                    "msg" => $e->getRpcCode()
+                    "rpccode" => $e->getRpcCode(),
+                    "rpcmsg" => $e->getRpcMsg(),
+                    "rpcdata" => $e->getRpcData(),
+                    "rpcresponse" => $e->getResponse(),
+                    "rpcid"     => $e->getRpcId()
                 ]);
             }
         });

--- a/develop/app/Controllers/v1/RpcApi.php
+++ b/develop/app/Controllers/v1/RpcApi.php
@@ -10,18 +10,20 @@ class RpcApi implements Evaluator
 {
     public function evaluate($method, $arguments)
     {
-        if ($method === 'add') {
-            return self::add($arguments);
+        switch ($method) {
+            case "add":
+                return self::add($arguments);
+            case "implementationError":   
+                return self::implementationError($arguments);
+            case "InternalError":
+                return self::InternalError();
+            case "error429RpcServer":
+                return self::error429RpcServer();
+            case "error500RpcServer":
+                return self::error500RpcServer();
+            default:
+                throw new MethodException();
         }
-        if ($method === 'implementationError') {
-            return self::implementationError($arguments);
-        }
-        if ($method === 'InternalError') {
-            return self::InternalError();
-        }
-        
-
-        throw new MethodException();
     }
 
     private static function add($arguments)
@@ -42,6 +44,16 @@ class RpcApi implements Evaluator
     private static function InternalError()
     {
         throw new \App\Controllers\V1\InternalErrorException();
+    }
+
+    private static function error429RpcServer()
+    {
+        return "Too Many Requests";
+    }
+
+    private static function error500RpcServer()
+    {
+        return "Internal Server Error";
     }
 }
 

--- a/develop/app/Controllers/v1/RpcApi.php
+++ b/develop/app/Controllers/v1/RpcApi.php
@@ -1,0 +1,79 @@
+<?php
+namespace App\Controllers\V1;
+
+use Datto\JsonRpc\Evaluator;
+use Datto\JsonRpc\Exceptions\ArgumentException;
+use Datto\JsonRpc\Exceptions\MethodException;
+use Datto\JsonRpc\Examples\Library\Math;
+
+class RpcApi implements Evaluator
+{
+    public function evaluate($method, $arguments)
+    {
+        if ($method === 'add') {
+            return self::add($arguments);
+        }
+        if ($method === 'implementationError') {
+            return self::implementationError($arguments);
+        }
+        if ($method === 'InternalError') {
+            return self::InternalError();
+        }
+        
+
+        throw new MethodException();
+    }
+
+    private static function add($arguments)
+    {
+        @list($a, $b) = $arguments;
+
+        if (!is_int($a) || !is_int($b)) {
+            throw new ArgumentException();
+        }
+        return $a+$b;
+    }
+
+    private static function implementationError($arguments)
+    {
+        throw new \Datto\JsonRpc\Exceptions\ImplementationException(-32099, @$arguments[0]);
+    }
+
+    private static function InternalError()
+    {
+        throw new \App\Controllers\V1\InternalErrorException();
+    }
+}
+
+?>
+<?php
+
+namespace App\Controllers\V1;
+
+use Datto\JsonRpc\Responses\ErrorResponse;
+
+/**
+ * If a method cannot be called (e.g. if the method doesn't exist, or is a
+ * private method), then you should throw a "MethodException".
+ *
+ * If the method is callable, but the user-supplied arguments are incompatible
+ * with the method's type signature, or an argument is invalid, then you should
+ * throw an "ArgumentException".
+ *
+ * If the method is callable, and the user-supplied arguments are valid, but an
+ * issue arose when the server-side application was evaluating the method, then
+ * you should throw an "ApplicationException".
+ *
+ * If you've extended this JSON-RPC 2.0 library, and an issue arose in your
+ * implementation of the JSON-RPC 2.0 specifications, then you should throw an
+ * "ImplementationException".
+ *
+ * @link http://www.jsonrpc.org/specification#error_object
+ */
+class InternalErrorException extends \Datto\JsonRpc\Exceptions\Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Internal error', -32603);
+    }
+}

--- a/develop/composer.json
+++ b/develop/composer.json
@@ -8,7 +8,8 @@
 		"php": "^7.3||^8.0",
 		"codeigniter4/framework": "^4",
 		"psr/http-message": "^1.0",
-		"guzzlehttp/guzzle": "7.0"
+		"guzzlehttp/guzzle": "7.0",
+		"datto/json-rpc": "^6.1"
 	},
 	"require-dev": {
 		"fakerphp/faker": "^1.9",

--- a/develop/composer.lock
+++ b/develop/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d039c3b77984de84f04475b1b286f31",
+    "content-hash": "750e16b72deabef742cab9004404eb0c",
     "packages": [
         {
             "name": "codeigniter4/framework",
@@ -62,6 +62,60 @@
                 "source": "https://github.com/codeigniter4/CodeIgniter4"
             },
             "time": "2021-02-01T18:41:38+00:00"
+        },
+        {
+            "name": "datto/json-rpc",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/datto/php-json-rpc.git",
+                "reference": "ad4d735f48d80c6b53f7405e5007d97c996533f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/datto/php-json-rpc/zipball/ad4d735f48d80c6b53f7405e5007d97c996533f6",
+                "reference": "ad4d735f48d80c6b53f7405e5007d97c996533f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Datto\\JsonRpc\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Spencer Mortensen",
+                    "email": "smortensen@datto.com",
+                    "homepage": "http://spencermortensen.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Fully unit-tested JSON-RPC 2.0 for PHP",
+            "homepage": "http://datto.com",
+            "keywords": [
+                "json",
+                "json-rpc",
+                "jsonrpc",
+                "php",
+                "php-json-rpc",
+                "rpc"
+            ],
+            "support": {
+                "issues": "https://github.com/datto/php-json-rpc/issues",
+                "source": "https://github.com/datto/php-json-rpc/tree/6.1.0"
+            },
+            "time": "2020-02-28T23:54:06+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3010,5 +3064,5 @@
         "php": "^7.3||^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/develop/tests/Anser/Service/ActionTest.php
+++ b/develop/tests/Anser/Service/ActionTest.php
@@ -326,7 +326,7 @@ class ActionTest extends CIUnitTestCase
 
         $method = 'add';
         $param  = [1,2]; 
-        $id     = 1;
+        $id = "1";
 
         $rpcClient = ServiceList::getRpcClient();
         $testRpcRequest = $rpcClient->query($id, $method, $param)->encode();
@@ -346,7 +346,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'add';
         $param  = [1,2]; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -364,7 +364,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'failMethod';
         $param  = [1,2]; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -393,7 +393,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'add';
         $param  = []; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -453,7 +453,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'add';
         $param  = [1,2]; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -488,7 +488,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'implementationError';
         $param  = [1,2]; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -517,7 +517,7 @@ class ActionTest extends CIUnitTestCase
     {
         $method = 'InternalError';
         $param  = [1,2]; 
-        $id = 1;
+        $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
         $action->setRpcQuery($method, $param,$id); 
@@ -540,5 +540,526 @@ class ActionTest extends CIUnitTestCase
         $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
         $this->assertEquals($errorCode,-32603);
         $this->assertEquals($action->getMeaningData()["msg"],"Internal error");
+    }
+
+    public function testFailRpcHandler400ActionDo()
+    {
+        $method = 'error429RpcServer';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                $response = $e->getResponse();
+                $action = $e->getAction();
+                $errorCode = $e->getStatusCode();
+                $action->setMeaningData([
+                    "code" => $errorCode,
+                    "rpcCode" => $e->getRpcCode(),
+                    "rpcMsg" => $e->getRpcMsg(),
+                    "rpcData" => $e->getRpcData(),
+                    "rpcId"     => $e->getRpcId()
+                ]);   
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertNull($action->getMeaningData()["rpcCode"]);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Too Many Requests");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler500ActionDo()
+    {
+        $method = 'error500RpcServer';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                $response = $e->getResponse();
+                $action = $e->getAction();
+                $errorCode = $e->getStatusCode();
+                $action->setMeaningData([
+                    "code" => $errorCode,
+                    "rpcCode" => $e->getRpcCode(),
+                    "rpcMsg" => $e->getRpcMsg(),
+                    "rpcData" => $e->getRpcData(),
+                    "rpcId"     => $e->getRpcId()
+                ]);       
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertNull($action->getMeaningData()["rpcCode"]);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal Server Error");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testRpcConnectionError()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("errorService","POST","/api/v1/rpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $action->failHandler(function(ActionException $e){
+            if($e->isConnectError()){
+                $e->getAction()->setMeaningData("connectError");
+            }
+        })->setTimeout(1.0)->do();
+        $this->assertEquals($action->getMeaningData(),"connectError");
+
+        $action = new Action("errorService","POST","/api/v1/rpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        try {
+            $action->setTimeout(1.0)->do();
+        } catch (\SDPMlab\Anser\Exception\ActionException $e) {
+            $this->assertInstanceOf(ActionException::class,$e);
+            $this->assertTrue($e->isConnectError());
+        }
+    }
+
+    public function testFailRpcHandler400WithMethodNotExistActionDo()
+    {
+        $method = 'a';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcMethodError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32601);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Method not found");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler500WithMethodNotExistActionDo()
+    {
+        $method = 'a';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcMethodError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }    
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32601);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Method not found");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler400WithParseErrorActionDo()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $closure = function () use ($action) {
+            $action->rpcRequest = '"{"jsonrpc":"2.0","method":"add","params":[1,}"';
+        };
+        $binding = $closure->bindTo($action , get_class($action ));
+        $binding();
+
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcParseError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32700);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Parse error");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertNull($action->getMeaningData()["rpcId"]);
+    }
+
+    public function testFailRpcHandler500WithParseErrorActionDo()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $closure = function () use ($action) {
+            $action->rpcRequest = '"{"jsonrpc":"2.0","method":"add","params":[1,}"';
+        };
+        $binding = $closure->bindTo($action , get_class($action ));
+        $binding();
+
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcParseError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32700);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Parse error");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertNull($action->getMeaningData()["rpcId"]);
+    }
+
+    public function testFailRpcHandler400WithInvalidParamsActionDo()
+    {
+        $method = 'add';
+        $param  = []; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcInvalidParams()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32602);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid params");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler500WithInvalidParamsActionDo()
+    {
+        $method = 'add';
+        $param  = []; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcInvalidParams()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }    
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32602);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid params");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler400WithInvalidRequestActionDo()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $closure = function () use ($action) {
+            $action->rpcRequest = '[1,2,3]';
+        };
+        $binding = $closure->bindTo($action , get_class($action ));
+        $binding();
+
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcInvalidRequest()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32600);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid Request");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertNull($action->getMeaningData()["rpcId"]);
+    }
+
+    public function testFailRpcHandler500WithInvalidRequestActionDo()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $closure = function () use ($action) {
+            $action->rpcRequest = '[1,2,3]';
+        };
+        $binding = $closure->bindTo($action , get_class($action ));
+        $binding();
+
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcInvalidRequest()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32600);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid Request");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertNull($action->getMeaningData()["rpcId"]);
+    }
+
+    public function testFailRpcHandler400WithInternalErrorActionDo()
+    {
+        $method = 'InternalError';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcInternalError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32603);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal error");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler500WithInternalErrorActionDo()
+    {
+        $method = 'InternalError';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcInternalError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }    
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32603);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal error");
+        $this->assertNull($action->getMeaningData()["rpcData"]);
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+
+    public function testFailRpcHandler400WithInternalServerErrorActionDo()
+    {
+        $method = 'implementationError';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isClientError()){
+                if ($e->isRpcInternalServerError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,429);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32099);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Server error");
+        $this->assertEquals($action->getMeaningData()["rpcData"],"1");
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+    }
+    public function testFailRpcHandler500WithInternalServerErrorActionDo()
+    {
+        $method = 'implementationError';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
+        $action->setRpcQuery($method, $param,$id); 
+        $errorCode = 0;
+        $action->failHandler(function(ActionException $e) use (&$errorCode){
+            if($e->isServerError()){
+                if ($e->isRpcInternalServerError()) {
+                    $response = $e->getResponse();
+                    $action = $e->getAction();
+                    $errorCode = $e->getStatusCode();
+                    
+                    $action->setMeaningData([
+                        "code" => $errorCode,
+                        "rpcCode" => $e->getRpcCode(),
+                        "rpcMsg" => $e->getRpcMsg(),
+                        "rpcData" => $e->getRpcData(),
+                        "rpcId"     => $e->getRpcId()
+                    ]);  
+                }    
+            }
+        });
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertEquals($errorCode,500);
+        $this->assertEquals($action->getMeaningData()["rpcCode"],-32099);
+        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Server error");
+        $this->assertEquals($action->getMeaningData()["rpcData"],"1");
+        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  anser_service:
+    image: webdevops/php-nginx-dev:8.0
+    platform: linux/x86_64
+    ports:
+        - 8080:80
+    working_dir: /app
+    environment: 
+        - WEB_DOCUMENT_ROOT=/app/public
+        - PHP_MEMORY_LIMIT=512M
+        - PHP_MAX_EXECUTION_TIME=30
+        - PHP_POST_MAX_SIZE=20M
+        - PHP_UPLOAD_MAX_FILESIZE=20M
+    volumes:
+        - './develop:/app'
+        - './src:/src'

--- a/src/Exception/ActionException.php
+++ b/src/Exception/ActionException.php
@@ -189,44 +189,71 @@ class ActionException extends AnserException
     }
 
     /**
-     * 回傳RPC Response
+     * 回傳RPC Response 
+     * 可能發生於HTTP請求錯誤，但RPC回傳正確，以Response Type判斷
      *
-     * @return \Datto\JsonRpc\Responses\ErrorResponse
+     * @return \Datto\JsonRpc\Responses\ErrorResponse|\Datto\JsonRpc\Responses\ResultResponse
      */
-    public function getRpcResponse(): \Datto\JsonRpc\Responses\ErrorResponse
+    public function getRpcResponse(): \Datto\JsonRpc\Responses\ErrorResponse|\Datto\JsonRpc\Responses\ResultResponse
     {
         return \SDPMlab\Anser\Service\ServiceList::getRpcClient()->decode($this->response->getBody())[0];
     }
 
     /**
-     * 回傳RPC錯誤碼
+     * 回傳RPC Response id
      *
-     * @return integer
+     * @return string|null
      */
-    public function getRpcCode(): int
+    public function getRpcId(): ?string
     {
-        return $this->getRpcResponse()->getCode();
+        return $this->getRpcResponse()->getId();
     }
 
     /**
-     * 回傳RPC錯誤訊息
+     * 回傳RPC錯誤碼
+     * 當 Response Type 為 ErrorResponse 時，回傳 error code，如果非 ErrorResponse 則回傳null
      *
-     * @return string
+     * @return integer|null
      */
-    public function getRpcMsg(): string
+    public function getRpcCode(): ?int
     {
-        return $this->getRpcResponse()->getMessage();
+        if ($this->getRpcResponse() instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+            return $this->getRpcResponse()->getCode();
+        }
+        return null;
+    }
+       
+
+    /**
+     * 回傳RPC錯誤訊息
+     * 當 Response Type 為 ErrorResponse 時，回傳 error message，如果為 ResultResponse 則回傳由 Response 原始資料
+     *
+     * @return string|null
+     */
+    public function getRpcMsg(): ?string
+    {
+        if ($this->getRpcResponse() instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+            return $this->getRpcResponse()->getMessage();
+        }
+        if ($this->getRpcResponse() instanceof \Datto\JsonRpc\Responses\ResultResponse) {
+            return $this->getRpcResponse()->getValue();
+        }
+        return null;
     }
 
     /**
      * 回傳RPC Data
      *
-     * @return array|null
+     * @return array|null|string|int
      */
-    public function getRpcData(): ?array
+    public function getRpcData(): array|null|string|int
     {
-        return $this->getRpcResponse()->getData();
+        if ($this->getRpcResponse() instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+            return $this->getRpcResponse()->getData();
+        }
+        return null;
     }
+    
 
     /**
      * 是否為 Client Error (Client code 4XX)

--- a/src/Exception/ActionException.php
+++ b/src/Exception/ActionException.php
@@ -317,4 +317,31 @@ class ActionException extends AnserException
         }
         return $this->getRpcCode() == -32600;
     }
+
+    /**
+     * RPC 內部錯誤
+     *
+     * @return boolean
+     */
+    public function isRpcInternalError(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+        return $this->getRpcCode() == -32603;
+    }
+
+    /**
+     * RPC Server端錯誤
+     *
+     * @return boolean
+     */
+    public function isRpcInternalServerError(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+
+        return $this->getRpcCode() <= -32000 && $this->getRpcCode() >= -32099;
+    }
 }

--- a/src/Exception/ActionException.php
+++ b/src/Exception/ActionException.php
@@ -97,6 +97,27 @@ class ActionException extends AnserException
         );
     }
 
+    public static function forRpcResponseError(
+        string $serviceName,
+        RequestSettings $requestSettings,
+        ActionInterface $action,
+        ?string $alias = null,
+        $rpcMsg
+    ): ActionException {
+        $msg = "Action {$serviceName} 在地址 {$requestSettings->url} 以 {$requestSettings->method} 方法呼叫 {$requestSettings->path} 時發生錯誤。JSON-RPC {$rpcMsg}";
+        if ($alias) {
+            $msg = "{$alias}-" . $msg;
+        }
+
+        return new self(
+            $msg,
+            $action->getResponse(),
+            null,
+            $action,
+            true
+        );
+    }
+
     public static function forRetryNumber(string $serviceName): ActionException
     {
         return new self("Action {$serviceName} Retry次數必須大於 0 。");
@@ -120,6 +141,11 @@ class ActionException extends AnserException
     public static function forServiceDataCallbackTypeError(string $serviceName): ActionException
     {
         return new self("Action {$serviceName} 定義的回呼函數回傳型別錯誤，請檢查回傳型別是否為 \SDPMlab\Anser\Service\ServiceSettings 或 null。");
+    }
+
+    public static function forRpcResponseErrorType(string $message,int $code): ActionException
+    {
+        return new self("code : {$code} , message : {$message}");
     }
 
     /**
@@ -163,6 +189,46 @@ class ActionException extends AnserException
     }
 
     /**
+     * 回傳RPC Response
+     *
+     * @return \Datto\JsonRpc\Responses\ErrorResponse
+     */
+    public function getRpcResponse(): \Datto\JsonRpc\Responses\ErrorResponse
+    {
+        return \SDPMlab\Anser\Service\ServiceList::getRpcClient()->decode($this->response->getBody())[0];
+    }
+
+    /**
+     * 回傳RPC錯誤碼
+     *
+     * @return integer
+     */
+    public function getRpcCode(): int
+    {
+        return $this->getRpcResponse()->getCode();
+    }
+
+    /**
+     * 回傳RPC錯誤訊息
+     *
+     * @return string
+     */
+    public function getRpcMsg(): string
+    {
+        return $this->getRpcResponse()->getMessage();
+    }
+
+    /**
+     * 回傳RPC Data
+     *
+     * @return array|null
+     */
+    public function getRpcData(): ?array
+    {
+        return $this->getRpcResponse()->getData();
+    }
+
+    /**
      * 是否為 Client Error (Client code 4XX)
      *
      * @return boolean
@@ -198,5 +264,57 @@ class ActionException extends AnserException
     public function isConnectError(): bool
     {
         return $this->isConnectError;
+    }
+
+    /**
+     * RPC 呼叫路徑錯誤
+     *
+     * @return boolean
+     */
+    public function isRpcMethodError(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+        return $this->getRpcCode() == -32601;
+    }
+
+    /**
+     * RPC 解析錯誤
+     *
+     * @return boolean
+     */
+    public function isRpcParseError(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+        return $this->getRpcCode() == -32700;
+    }
+
+    /**
+     * RPC 無效參數
+     *
+     * @return boolean
+     */
+    public function isRpcInvalidParams(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+        return $this->getRpcCode() == -32602;
+    }
+
+    /**
+     * RPC 無效的請求
+     *
+     * @return boolean
+     */
+    public function isRpcInvalidRequest(): bool
+    {
+        if(is_null($this->response)){
+            return false;
+        }
+        return $this->getRpcCode() == -32600;
     }
 }

--- a/src/Service/Action.php
+++ b/src/Service/Action.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\Utils;
 use Psr\Http\Message\ResponseInterface;
 use SDPMlab\Anser\Exception\ActionException;
+use SDPMlab\Anser\Exception\AnserException;
 use SDPMlab\Anser\Service\ActionFilter;
 use SDPMlab\Anser\Service\ActionInterface;
 use SDPMlab\Anser\Service\RequestSettings;
@@ -136,6 +137,13 @@ class Action implements ActionInterface
      */
     protected $client;
 
+    /**
+     * JSONRPC 請求
+     *
+     * @var string|null
+     */
+    protected $rpcRequest = null;
+
     public function __construct(string $serviceName, string $method, string $path)
     {
         $this->serviceName = $serviceName;
@@ -201,7 +209,8 @@ class Action implements ActionInterface
                 try {
                     //如果 numOfAction 大於 1 就代表是 retry
                     $response = $this->sendRequest($this->numOfAction > 1);
-                    $this->setActionResponse($response, true);
+                    // 將原本的setActionResponse放至verifyResponse呼叫
+                    $this->verifyResponse($response);
                     break;
                 } catch (\Exception $th) {
                     if ($this->numOfAction > $this->retry) {
@@ -212,6 +221,8 @@ class Action implements ActionInterface
             }
         } catch (\GuzzleHttp\Exception\TransferException $th){
             $this->processFailHandler($th);
+        } catch (ActionException $th) {
+            $this->processFailHandlerForRpc($th);
         }
 
         //執行後濾器
@@ -244,7 +255,12 @@ class Action implements ActionInterface
         )->then(
             function (ResponseInterface $res) use (&$runtimeAction) {
                 $runtimeAction->addNumOfActionDo();
-                $runtimeAction->setActionResponse($res, true);
+                try {
+                    // 將原本的setActionResponse放至verifyResponse呼叫
+                    $runtimeAction->verifyResponse($res);
+                } catch (ActionException $th) {
+                    return $runtimeAction->processFailHandlerForRpc($th);
+                }
                 //執行後濾器
                 $runtimeAction->useFilters(false);
                 //判斷是否需要過濾意義資料
@@ -365,6 +381,17 @@ class Action implements ActionInterface
                 throw $exception;
             }    
         }
+    }
+
+    public function processFailHandlerForRpc(ActionException $th,?string $alias = null)
+    {
+        $this->setActionResponse($this->response, false);
+        $exception = ActionException::forRpcResponseError($this->serviceName, $this->getRequestSetting(), $this, $alias, $th->getMessage());
+        if (is_callable($this->failHandler)) {
+            call_user_func($this->failHandler, $exception);
+        } else {
+            throw $exception;
+        }    
     }
 
     /**
@@ -488,6 +515,12 @@ class Action implements ActionInterface
             $finallyOptions["delay"] = ($this->retryDelay * 1000);
         }
 
+        // 如果rpc請求存在，則加入body
+        if (!is_null($this->rpcRequest)) {
+            $finallyOptions["body"] = $this->rpcRequest;
+            $this->method = "POST";
+        }
+        
         return $finallyOptions;
     }
 
@@ -679,5 +712,47 @@ class Action implements ActionInterface
         } else {
             return null;
         }
+    }
+
+    /**
+     * 設定JSON RPC 呼叫參數
+     *
+     * @param string|null $method
+     * @param array $arguments
+     * @return ActionInterface
+     */
+    public function setRpcQuery(string $method = null, array $arguments = []): ActionInterface
+    {
+        $rpcClient = ServiceList::getRpcClient();
+
+        // the rpc unique id
+        $id = sha1(
+            uniqid() .
+            substr(str_shuffle(str_repeat($x='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil(10/strlen($x)))), 1, 10)
+        );
+
+        $rpcClient->query($id, $method, $arguments);
+
+        $this->rpcRequest = $rpcClient->encode();
+
+        return $this;
+    }
+
+    /**
+     * 判斷Response是否為RPC Response，並解析是否有錯誤
+     *
+     * @param ResponseInterface $response
+     */
+    public function verifyResponse(ResponseInterface $response)
+    {
+        if (!is_null($this->rpcRequest)) {
+            $result = ServiceList::getRpcClient()->decode($response->getBody())[0];
+            if($result instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+                $this->setActionResponse($response,false);
+                throw ActionException::forRpcResponseErrorType($result->getMessage(), $result->getCode());
+            }
+        }
+        $this->setActionResponse($response,true);
+        return ;
     }
 }

--- a/src/Service/Action.php
+++ b/src/Service/Action.php
@@ -721,7 +721,7 @@ class Action implements ActionInterface
      * @param array $arguments
      * @return ActionInterface
      */
-    public function setRpcQuery(string $method = null, array $arguments = [], $id = null): ActionInterface
+    public function setRpcQuery(string $method = null, array $arguments = [], ?string $id = null): ActionInterface
     {
         $rpcClient = ServiceList::getRpcClient();
 

--- a/src/Service/ActionInterface.php
+++ b/src/Service/ActionInterface.php
@@ -248,6 +248,13 @@ interface ActionInterface
     public function setRpcQuery(string $method = null, array $arguments = []): ActionInterface;
 
     /**
+     * 取得當前RPC請求json
+     *
+     * @return ?string
+     */
+    public function getRpcRequest(): ?string;
+
+    /**
      * 判斷Response是否為RPC Response，並解析是否有錯誤
      *
      * @param ResponseInterface $response

--- a/src/Service/ActionInterface.php
+++ b/src/Service/ActionInterface.php
@@ -238,4 +238,20 @@ interface ActionInterface
      */
     public function getOption(string $optionName);
 
+    /**
+     * 設定JSON RPC 呼叫參數
+     *
+     * @param string|null $method
+     * @param array $arguments
+     * @return ActionInterface
+     */
+    public function setRpcQuery(string $method = null, array $arguments = []): ActionInterface;
+
+    /**
+     * 判斷Response是否為RPC Response，並解析是否有錯誤
+     *
+     * @param ResponseInterface $response
+     */
+    public function verifyResponse(ResponseInterface $response);
+
 }

--- a/src/Service/ServiceList.php
+++ b/src/Service/ServiceList.php
@@ -5,6 +5,7 @@ namespace SDPMlab\Anser\Service;
 use SDPMlab\Anser\Service\ServiceSettings;
 use GuzzleHttp\HandlerStack;
 use SDPMlab\Anser\Exception\ActionException;
+
 class ServiceList
 {
 
@@ -35,6 +36,13 @@ class ServiceList
      * @var \GuzzleHttp\Client
      */
     protected static $client;
+
+    /**
+     * Datto JsonRpc Client Instance
+     *
+     * @var \Datto\JsonRpc\Client
+     */
+    protected static $rpcClient;
 
     /**
      * Set local service list
@@ -181,5 +189,20 @@ class ServiceList
             }
         }
         return static::$client;
+    }
+
+    /**
+     * Get Datto JSONRPC Client
+     *
+     * @return \Datto\JsonRpc\Client
+     */
+    public static function getRpcClient(): \Datto\JsonRpc\Client
+    {
+        if(!static::$rpcClient instanceof \Datto\JsonRpc\Client){
+            if(static::$rpcClient === null){
+                static::$rpcClient = new \Datto\JsonRpc\Client();
+            }
+        }
+        return static::$rpcClient;
     }
 }


### PR DESCRIPTION
**Description**
Changed scope: 
1. Add  the `datto/json-rpc` library.
2. Add  the `rpcClient` to `ServiceList.php`
3. Changed the method `do` and `doAsync`  of `Action.php` 
4. Add  the method `processFailHandlerForRpc` to process fail rpc response.
5. Add the method `setRpcQuery` and `verifyResponse` to process rpc request.
6. Add some RPC exception handling methods to ActionException.php

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide