### PR TITLE
Enhanced : Batch JSON-RPC logic.

### DIFF
--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -39,30 +39,52 @@ class Rpc extends BaseController
     public function doSingleAction()
     {
         $action = (new Action(
-            env('serviceAddress'),
-            "GET",
-            "/"
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
         ))
-        ->setRpcQuery("/producth/index",[])
+        ->setTimeout(5)
+        ->setBatchRpcQuery([
+            ["add",[1,2]],
+            ["add",[1,2]],
+        ])
         ->doneHandler(static function(
             ResponseInterface $response,
             Action $runtimeAction
         ) {
-
-            $body = ServiceList::getRpcClient()->decode($response->getBody())[0]->getValue();
-            $runtimeAction->setMeaningData($body);
+            $rpcResponse = $runtimeAction->getRpcResponse();
+            $rpcResultArr = $runtimeAction->getRpcResult();
+            $rpcIdArr = $runtimeAction->getRpcId();
+            $runtimeAction->setMeaningData([
+                "response" => $rpcResponse,
+                "rpcResultArr" => $rpcResultArr,
+                "rpcIdArr" => $rpcIdArr
+            ]);
         })
         ->failHandler(function (
             ActionException $e
         ){
-            if ($e->isRpcMethodError()) {
+            if ($e->isRpcError()) {
+                $errorResArr = $e->getErrorRpc();
+                $successResArr = $e->getSuccessRpc();
+                $result = [];
+                foreach ($errorResArr as $errorRes) {
+                    $result["error"][] = [
+                        "Id" => $errorRes->getId(),
+                        "msg" => $errorRes->getMessage(),
+                        "code" => $errorRes->getCode(),
+                        "data" => $errorRes->getData()
+                    ];
+                }
+                foreach ($successResArr as $successRes) {
+                    $result["success"][] = [
+                        "Id" => $successRes->getId(),
+                        "result" => $successRes->getValue(),
+                    ];
+                }
                 $e->getAction()->setMeaningData([
                     "code" => 400,
-                    "rpccode" => $e->getRpcCode(),
-                    "rpcmsg" => $e->getRpcMsg(),
-                    "rpcdata" => $e->getRpcData(),
-                    "rpcresponse" => $e->getResponse(),
-                    "rpcid"     => $e->getRpcId()
+                    "result" => $result
                 ]);
             }
         });

--- a/develop/app/Controllers/v1/Rpc.php
+++ b/develop/app/Controllers/v1/Rpc.php
@@ -54,11 +54,9 @@ class Rpc extends BaseController
         ) {
             $rpcResponse = $runtimeAction->getRpcResponse();
             $rpcResultArr = $runtimeAction->getRpcResult();
-            $rpcIdArr = $runtimeAction->getRpcId();
             $runtimeAction->setMeaningData([
                 "response" => $rpcResponse,
                 "rpcResultArr" => $rpcResultArr,
-                "rpcIdArr" => $rpcIdArr
             ]);
         })
         ->failHandler(function (

--- a/develop/tests/Anser/Service/ActionTest.php
+++ b/develop/tests/Anser/Service/ActionTest.php
@@ -320,27 +320,6 @@ class ActionTest extends CIUnitTestCase
         $this->assertEquals($action->getNumnerOfDoAction(),1);
         $this->assertEquals($action->isSuccess(),true);
     }
-    public function testSetRpcQueryFunction()
-    {
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $rpcClient = ServiceList::getRpcClient();
-        $testRpcRequest = $rpcClient->query($id, $method, $param)->encode();
-        $testRpcDecode = json_decode($testRpcRequest,true);
-
-        $action->setRpcQuery($method, $param, $id);
-        $rpcRequest = $action->getRpcRequest();
-        $rpcDecode = json_decode($rpcRequest,true);
-
-        $this->assertNotNull($rpcRequest);
-        $this->assertEquals($rpcDecode["method"],$testRpcDecode["method"]);
-        $this->assertEquals($rpcDecode["params"],$testRpcDecode["params"]);
-        $this->assertEquals($rpcDecode["id"],$testRpcDecode["id"]);
-    }
 
     public function testRPCActionDo()
     {
@@ -353,713 +332,410 @@ class ActionTest extends CIUnitTestCase
         $action->do();
         $response = $action->getResponse();
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $data = ServiceList::getRpcClient()->decode($response->getBody())[0];
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class, $data);
-        $this->assertEquals($data->getValue(),3); 
-        $this->assertEquals($data->getId(),$id);
+        $rpcResponse = $action->getRpcResponse();
+        $this->assertIsArray($rpcResponse);
+        $this->assertEquals(count($rpcResponse),1);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\Response::class, $rpcResponse[0]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class, $rpcResponse[0]);
+        $data = $action->getRpcResult();
+        $this->assertEquals($data[0],3); 
+        $id   = $action->getRpcId();
+        $this->assertEquals($id[0],1);
+        $this->assertEquals($action->isSuccess(),true);
+    }
+    
+    public function testBatchRPCActionDo()
+    {
+        $method = 'add';
+        $param  = [1,2]; 
+        $id = "1";
+
+        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
+        $action->setBatchRpcQuery([
+            [$method, $param,$id],
+            [$method, $param,$id],
+            [$method, $param,$id]
+        ]); 
+        $action->do();
+        $response = $action->getResponse();
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $rpcResponse = $action->getRpcResponse();
+        $this->assertIsArray($rpcResponse);
+        $this->assertEquals(count($rpcResponse),3);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\Response::class, $rpcResponse[0]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class, $rpcResponse[0]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\Response::class, $rpcResponse[1]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class, $rpcResponse[1]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\Response::class, $rpcResponse[2]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class, $rpcResponse[2]);
+        $data = $action->getRpcResult();
+        $this->assertEquals($data[0],3); 
+        $this->assertEquals($data[1],3); 
+        $this->assertEquals($data[2],3); 
+        $id   = $action->getRpcId();
+        $this->assertEquals($id[0],1); 
+        $this->assertEquals($id[1],1); 
+        $this->assertEquals($id[2],1); 
         $this->assertEquals($action->isSuccess(),true);
     }
 
-    public function testFailRPCHandlerMethodNotFoundActionDo()
+    public function testFailHandlerBatchRPCErrorActionDo()
     {
         $method = 'failMethod';
         $param  = [1,2]; 
         $id = "1";
 
         $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-            if($e->isRpcMethodError()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
-                    "code" => 404,
-                    "msg" => $e->getRpcMsg()
-                ]);    
+        $action->setBatchRpcQuery([
+            [$method, $param,$id],
+            [$method, $param,$id],
+            [$method, $param,$id]
+        ]); 
+        $errRpc = [];
+        $sucRpc = [];
+        $action->failHandler(function(ActionException $e) use (&$errRpc,&$sucRpc){
+            if($e->isRpcError()){
+                $errRpc = $e->getErrorRpc();
+                $sucRpc = $e->getSuccessRpc();
             }
         });
         
         $this->assertIsCallable($action->getFaileHandler());
         $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32601);
-        $this->assertEquals($action->getMeaningData()["msg"],"Method not found");
+        $this->assertIsArray($errRpc);
+        $this->assertNull($sucRpc);
+        $this->assertEquals(count($errRpc),3);
     }
 
-    public function testFailRPCHandlerInvalidParamsActionDo()
+    public function testFailHandlerBatchRPCSuccessAndErrorActionDo()
+    {
+        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
+        $action->setBatchRpcQuery([
+            ["failMethod", [1,2],"1"],
+            ["add", [1,2],"1"],
+            ["failMethod", [1,2],"1"]
+        ]); 
+        $action->setTimeout(3);
+        $errRpc = [];
+        $sucRpc = [];
+        $action->failHandler(function(ActionException $e) use (&$errRpc,&$sucRpc){
+            if($e->isRpcError()){
+                $errRpc = $e->getErrorRpc();
+                $sucRpc = $e->getSuccessRpc();
+            }
+        });
+        
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertIsArray($errRpc);
+        $this->assertIsArray($sucRpc);
+        $this->assertEquals(count($errRpc),2);
+        $this->assertEquals(count($sucRpc),1);
+    }
+
+    public function testRPCGetFailDetailsActionDo()
+    {
+        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
+        $action->setBatchRpcQuery([
+            ["failMethod", [1,2],"1"],
+            ["add", [1,2],"1"],
+            ["failMethod", [1,2],"1"]
+        ]); 
+        $errRpc = [];
+        $sucRpc = [];
+        $action->failHandler(function(ActionException $e) use (&$errRpc,&$sucRpc){
+            if($e->isRpcError()){
+                $errRpc = $e->getErrorRpc();
+                $sucRpc = $e->getSuccessRpc();
+            }
+        });
+        
+        $this->assertIsCallable($action->getFaileHandler());
+        $action->do();
+        $this->assertIsArray($errRpc);
+        $this->assertIsArray($sucRpc);
+        $this->assertEquals(count($errRpc),2);
+        $this->assertEquals(count($sucRpc),1);
+        $this->assertEquals($errRpc[0]->getId(),1);
+        $this->assertEquals($errRpc[0]->getMessage(),"Method not found");
+        $this->assertEquals($errRpc[0]->getCode(),-32601);
+        $this->assertNull($errRpc[0]->getData());
+        $this->assertEquals($errRpc[1]->getId(),1);
+        $this->assertEquals($errRpc[1]->getMessage(),"Method not found");
+        $this->assertEquals($errRpc[1]->getCode(),-32601);
+        $this->assertNull($errRpc[1]->getData());
+        $this->assertEquals($sucRpc[0]->getId(),1);
+        $this->assertEquals($sucRpc[0]->getValue(),3);
+    }
+
+    public function testDoneHandlerRpcQueryDoActionWithGetData()
     {
         $method = 'add';
-        $param  = []; 
+        $param  = [1,2]; 
         $id = "1";
 
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-            if($e->isRpcInvalidParams()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
-                    "code" => 500,
-                    "msg" => $e->getRpcMsg()
-                ]);    
-            }
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
+        ))
+        ->setTimeout(5)
+        ->setRpcQuery($method,$param,$id)
+        ->doneHandler(static function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ) {
+            $rpcResponse = $runtimeAction->getRpcResponse();
+            $rpcResultArr = $runtimeAction->getRpcResult();
+            $rpcIdArr = $runtimeAction->getRpcId();
+            $runtimeAction->setMeaningData([
+                "response" => $rpcResponse,
+                "rpcResultArr" => $rpcResultArr,
+                "rpcIdArr" => $rpcIdArr
+            ]);
         });
         
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32602);
-        $this->assertEquals($action->getMeaningData()["msg"],"Invalid params");
+        $data = $action->do()->getMeaningData();
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class,$data["response"][0]);
+        $this->assertEquals($data["rpcResultArr"][0],3);
+        $this->assertNotNull($data["rpcIdArr"][0]);
     }
 
-    public function testFailRPCHandlerInvalidRequestActionDo()
+    public function testFailHandlerRpcQueryDoActionWithGetData()
     {
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $closure = function () use ($action) {
-            $action->rpcRequest = '[1,2,3]';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
+        $method = 'failMethod';
+        $param  = [1,2]; 
+        $id = "1";
 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-
-            if($e->isRpcInvalidRequest()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
+        ))
+        ->setTimeout(5)
+        ->setRpcQuery($method,$param,$id)
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcError()) {
+                $errorResArr = $e->getErrorRpc();
+                $result = [];
+                foreach ($errorResArr as $errorRes) {
+                    $result["error"][] = [
+                        "response" => $errorRes,
+                        "Id" => $errorRes->getId(),
+                        "msg" => $errorRes->getMessage(),
+                        "code" => $errorRes->getCode(),
+                        "data" => $errorRes->getData()
+                    ];
+                }
+                $e->getAction()->setMeaningData([
                     "code" => 400,
-                    "msg" => $e->getRpcMsg()
-                ]);    
+                    "result" => $result
+                ]);
             }
         });
-        
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32600);
-        $this->assertEquals($action->getMeaningData()["msg"],"Invalid Request");
+
+        $data = $action->do()->getMeaningData();
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class,$data["result"]["error"][0]["response"]);
+        $this->assertNotNull($data["result"]["error"][0]["Id"]);
+        $this->assertEquals($data["result"]["error"][0]["msg"],"Method not found");
+        $this->assertEquals($data["result"]["error"][0]["code"],-32601);
+        $this->assertNull($data["result"]["error"][0]["data"]);
     }
 
-    public function testFailRPCHandlerParseErrorActionDo()
+    public function testDoneHandlerBatchRpcQueryDoActionWithGetData()
     {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
+        ))
+        ->setTimeout(5)
+        ->setBatchRpcQuery([
+            ["add",[1,2]],
+            ["add",[1,2]],
+        ])
+        ->doneHandler(static function(
+            ResponseInterface $response,
+            Action $runtimeAction
+        ) {
+            $rpcResponse = $runtimeAction->getRpcResponse();
+            $rpcResultArr = $runtimeAction->getRpcResult();
+            $rpcIdArr = $runtimeAction->getRpcId();
+            $runtimeAction->setMeaningData([
+                "response" => $rpcResponse,
+                "rpcResultArr" => $rpcResultArr,
+                "rpcIdArr" => $rpcIdArr
+            ]);
+        });
 
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $closure = function () use ($action) {
-            $action->rpcRequest = '"{"jsonrpc":"2.0","method":"add","params":[1,}"';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
+        $data = $action->do()->getMeaningData();
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class,$data["response"][0]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class,$data["response"][1]);
+        $this->assertEquals($data["rpcResultArr"][0],3);
+        $this->assertEquals($data["rpcResultArr"][1],3);
+        $this->assertNotNull($data["rpcIdArr"][0]);
+        $this->assertNotNull($data["rpcIdArr"][1]);
+    }
 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-            if($e->isRpcParseError()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
-                    "code" => 500,
-                    "msg" => $e->getRpcMsg()
-                ]);    
+    public function testFailHandlerBatchRpcQueryDoActionWithAllFailData()
+    {
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
+        ))
+        ->setTimeout(5)
+        ->setBatchRpcQuery([
+            ["failMethod",[1,2]],
+            ["failMethod",[1,2]],
+        ])
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcError()) {
+                $errorResArr = $e->getErrorRpc();
+                $successResArr = $e->getSuccessRpc();
+                $result = [];
+                foreach ($errorResArr as $errorRes) {
+                    $result["error"][] = [
+                        "response" => $errorRes,
+                        "Id" => $errorRes->getId(),
+                        "msg" => $errorRes->getMessage(),
+                        "code" => $errorRes->getCode(),
+                        "data" => $errorRes->getData()
+                    ];
+                }
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "result" => $result, // fail Result
+                    "successResult" => $successResArr
+                ]);
             }
         });
-        
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32700);
-        $this->assertEquals($action->getMeaningData()["msg"],"Parse error");
+
+        $data = $action->do()->getMeaningData();
+        $this->assertEquals(count($data["result"]["error"]),2);
+        $this->assertNull($data["successResult"]);
+
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class,$data["result"]["error"][0]["response"]);
+        $this->assertNotNull($data["result"]["error"][0]["Id"]);
+        $this->assertEquals($data["result"]["error"][0]["msg"],"Method not found");
+        $this->assertEquals($data["result"]["error"][0]["code"],-32601);
+        $this->assertNull($data["result"]["error"][0]["data"]);
+
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class,$data["result"]["error"][1]["response"]);
+        $this->assertNotNull($data["result"]["error"][1]["Id"]);
+        $this->assertEquals($data["result"]["error"][1]["msg"],"Method not found");
+        $this->assertEquals($data["result"]["error"][1]["code"],-32601);
+        $this->assertNull($data["result"]["error"][1]["data"]);
     }
 
-    public function testFailRPCHandlerServerErrorActionDo()
+    public function testFailHandlerBatchRpcQueryDoActionWithSuccessAndFailData()
     {
-        $method = 'implementationError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-            if($e->isRpcInternalServerError()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
-                    "code" => 500,
-                    "msg" => $e->getRpcMsg()
-                ]);    
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/rpcServer"
+        ))
+        ->setTimeout(5)
+        ->setBatchRpcQuery([
+            ["add",[1,2]],
+            ["failMethod",[1,2]],
+        ])
+        ->failHandler(function (
+            ActionException $e
+        ){
+            if ($e->isRpcError()) {
+                $errorResArr = $e->getErrorRpc();
+                $successResArr = $e->getSuccessRpc();
+                $result = [];
+                foreach ($errorResArr as $errorRes) {
+                    $result["error"][] = [
+                        "response" => $errorRes,
+                        "Id" => $errorRes->getId(),
+                        "msg" => $errorRes->getMessage(),
+                        "code" => $errorRes->getCode(),
+                        "data" => $errorRes->getData()
+                    ];
+                }
+                foreach ($successResArr as $successRes) {
+                    $result["success"][] = [
+                        "response" => $successRes,
+                        "Id" => $successRes->getId(),
+                        "result" => $successRes->getValue(),
+                    ];
+                }
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "result" => $result,
+                ]);
             }
         });
-        
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32099);
-        $this->assertEquals($action->getMeaningData()["msg"],"Server error");
+
+        $data = $action->do()->getMeaningData();
+        $this->assertEquals(count($data["result"]["error"]),1);
+        $this->assertEquals(count($data["result"]["success"]),1);
+
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class,$data["result"]["success"][0]["response"]);
+        $this->assertNotNull($data["result"]["success"][0]["Id"]);
+        $this->assertEquals($data["result"]["success"][0]["result"],3);
+
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class,$data["result"]["error"][0]["response"]);
+        $this->assertNotNull($data["result"]["error"][0]["Id"]);
+        $this->assertEquals($data["result"]["error"][0]["msg"],"Method not found");
+        $this->assertEquals($data["result"]["error"][0]["code"],-32601);
+        $this->assertNull($data["result"]["error"][0]["data"]);
     }
 
-    public function testFailRPCHandlerInternalErrorActionDo()
+    public function testFailHandlerBatchRpcQueryDoActionWith4XXError()
     {
-        $method = 'InternalError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080", "POST", "/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = -1;
-        $response = null;
-        $action->failHandler(function(ActionException $e) use (&$errorCode,&$response){
-            if($e->isRpcInternalError()){
-                $response = $e->getRpcResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getRpcCode();
-                $action->setMeaningData([
-                    "code" => 500,
-                    "msg" => $e->getRpcMsg()
-                ]);    
-            }
-        });
-        
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class, $response);
-        $this->assertEquals($errorCode,-32603);
-        $this->assertEquals($action->getMeaningData()["msg"],"Internal error");
-    }
-
-    public function testFailRpcHandler400ActionDo()
-    {
-        $method = 'error429RpcServer';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
         $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
+        $action = (new Action(
+            "http://localhost:8080",
+            "POST",
+            "/api/v1/error429RpcServer"
+        ))
+        ->setTimeout(5)
+        ->setBatchRpcQuery([
+            ["add",[1,2]],
+            ["failMethod",[1,2]],
+        ])
+        ->failHandler(function (
+            ActionException $e
+        ) use (&$errorCode){
             if($e->isClientError()){
-                $response = $e->getResponse();
-                $action = $e->getAction();
                 $errorCode = $e->getStatusCode();
-                $action->setMeaningData([
-                    "code" => $errorCode,
-                    "rpcCode" => $e->getRpcCode(),
-                    "rpcMsg" => $e->getRpcMsg(),
-                    "rpcData" => $e->getRpcData(),
-                    "rpcId"     => $e->getRpcId()
-                ]);   
+                $rpcResponses = $e->getRpcByResponse();
+                $sucResponse = $e->getSuccessRpcByResponse();
+                $errResponse = $e->getErrorRpcByResponse();
+                $e->getAction()->setMeaningData([
+                    "code" => 400,
+                    "response" => $rpcResponses,
+                    "success" => [
+                        "id" => $sucResponse[0]->getId(),
+                        "result" => $sucResponse[0]->getValue()
+                    ],
+                    "error" => [
+                        "id" => $errResponse[0]->getId(),
+                        "msg" => $errResponse[0]->getMessage(),
+                        "code" => $errResponse[0]->getCode(),
+                        "data" => $errResponse[0]->getData()
+                    ]
+                ]);
             }
         });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertNull($action->getMeaningData()["rpcCode"]);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Too Many Requests");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
+
+        $data = $action->do()->getMeaningData();
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ResultResponse::class,$data["response"][0]);
+        $this->assertInstanceOf(\Datto\JsonRpc\Responses\ErrorResponse::class,$data["response"][1]);
+        $this->assertNotNull($data["success"]["id"]);
+        $this->assertEquals($data["success"]["result"],3);
+        $this->assertNotNull($data["error"]["id"]);
+        $this->assertEquals($data["error"]["msg"],"Method not found");
+        $this->assertEquals($data["error"]["code"],-32601);
+        $this->assertNull($data["error"]["data"]);
     }
-
-    public function testFailRpcHandler500ActionDo()
-    {
-        $method = 'error500RpcServer';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                $response = $e->getResponse();
-                $action = $e->getAction();
-                $errorCode = $e->getStatusCode();
-                $action->setMeaningData([
-                    "code" => $errorCode,
-                    "rpcCode" => $e->getRpcCode(),
-                    "rpcMsg" => $e->getRpcMsg(),
-                    "rpcData" => $e->getRpcData(),
-                    "rpcId"     => $e->getRpcId()
-                ]);       
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertNull($action->getMeaningData()["rpcCode"]);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal Server Error");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testRpcConnectionError()
-    {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("errorService","POST","/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $action->failHandler(function(ActionException $e){
-            if($e->isConnectError()){
-                $e->getAction()->setMeaningData("connectError");
-            }
-        })->setTimeout(1.0)->do();
-        $this->assertEquals($action->getMeaningData(),"connectError");
-
-        $action = new Action("errorService","POST","/api/v1/rpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        try {
-            $action->setTimeout(1.0)->do();
-        } catch (\SDPMlab\Anser\Exception\ActionException $e) {
-            $this->assertInstanceOf(ActionException::class,$e);
-            $this->assertTrue($e->isConnectError());
-        }
-    }
-
-    public function testFailRpcHandler400WithMethodNotExistActionDo()
-    {
-        $method = 'a';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcMethodError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32601);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Method not found");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler500WithMethodNotExistActionDo()
-    {
-        $method = 'a';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcMethodError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }    
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32601);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Method not found");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler400WithParseErrorActionDo()
-    {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $closure = function () use ($action) {
-            $action->rpcRequest = '"{"jsonrpc":"2.0","method":"add","params":[1,}"';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
-
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcParseError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32700);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Parse error");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertNull($action->getMeaningData()["rpcId"]);
-    }
-
-    public function testFailRpcHandler500WithParseErrorActionDo()
-    {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $closure = function () use ($action) {
-            $action->rpcRequest = '"{"jsonrpc":"2.0","method":"add","params":[1,}"';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
-
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcParseError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32700);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Parse error");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertNull($action->getMeaningData()["rpcId"]);
-    }
-
-    public function testFailRpcHandler400WithInvalidParamsActionDo()
-    {
-        $method = 'add';
-        $param  = []; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcInvalidParams()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32602);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid params");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler500WithInvalidParamsActionDo()
-    {
-        $method = 'add';
-        $param  = []; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcInvalidParams()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }    
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32602);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid params");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler400WithInvalidRequestActionDo()
-    {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $closure = function () use ($action) {
-            $action->rpcRequest = '[1,2,3]';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
-
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcInvalidRequest()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32600);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid Request");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertNull($action->getMeaningData()["rpcId"]);
-    }
-
-    public function testFailRpcHandler500WithInvalidRequestActionDo()
-    {
-        $method = 'add';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $closure = function () use ($action) {
-            $action->rpcRequest = '[1,2,3]';
-        };
-        $binding = $closure->bindTo($action , get_class($action ));
-        $binding();
-
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcInvalidRequest()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32600);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Invalid Request");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertNull($action->getMeaningData()["rpcId"]);
-    }
-
-    public function testFailRpcHandler400WithInternalErrorActionDo()
-    {
-        $method = 'InternalError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcInternalError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32603);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal error");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler500WithInternalErrorActionDo()
-    {
-        $method = 'InternalError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcInternalError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }    
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32603);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Internal error");
-        $this->assertNull($action->getMeaningData()["rpcData"]);
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-
-    public function testFailRpcHandler400WithInternalServerErrorActionDo()
-    {
-        $method = 'implementationError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error429RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isClientError()){
-                if ($e->isRpcInternalServerError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,429);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32099);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Server error");
-        $this->assertEquals($action->getMeaningData()["rpcData"],"1");
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
-    public function testFailRpcHandler500WithInternalServerErrorActionDo()
-    {
-        $method = 'implementationError';
-        $param  = [1,2]; 
-        $id = "1";
-
-        $action = new Action("http://localhost:8080","POST","/api/v1/error500RpcServer");
-        $action->setRpcQuery($method, $param,$id); 
-        $errorCode = 0;
-        $action->failHandler(function(ActionException $e) use (&$errorCode){
-            if($e->isServerError()){
-                if ($e->isRpcInternalServerError()) {
-                    $response = $e->getResponse();
-                    $action = $e->getAction();
-                    $errorCode = $e->getStatusCode();
-                    
-                    $action->setMeaningData([
-                        "code" => $errorCode,
-                        "rpcCode" => $e->getRpcCode(),
-                        "rpcMsg" => $e->getRpcMsg(),
-                        "rpcData" => $e->getRpcData(),
-                        "rpcId"     => $e->getRpcId()
-                    ]);  
-                }    
-            }
-        });
-        $this->assertIsCallable($action->getFaileHandler());
-        $action->do();
-        $this->assertEquals($errorCode,500);
-        $this->assertEquals($action->getMeaningData()["rpcCode"],-32099);
-        $this->assertEquals($action->getMeaningData()["rpcMsg"],"Server error");
-        $this->assertEquals($action->getMeaningData()["rpcData"],"1");
-        $this->assertEquals($action->getMeaningData()["rpcId"],"1");
-    }
+    
 }

--- a/src/Exception/ActionException.php
+++ b/src/Exception/ActionException.php
@@ -168,6 +168,11 @@ class ActionException extends AnserException
         return new self("Action {$serviceName} 已使用 setBatchRpcQuery() ，但未傳入任何資料於陣列中。");
     }
 
+    public static function forSetBatchRpcQueryIdRepeat(string $serviceName): ActionException
+    {
+        return new self("Action {$serviceName} 已使用 setBatchRpcQuery() ，但傳入ID重複。");
+    }
+    
     public static function forRpcInvalidResponse(string $serviceName): ActionException
     {
         return new self("Action {$serviceName} RPC Response 格式錯誤。");
@@ -223,20 +228,42 @@ class ActionException extends AnserException
      * 回傳解構後RPC Response 
      * 內部包裹success與error case的RPC Response物件
      *
-     * @return array
+     * @return array|null
      */
-    public function getRpcResponse(): array
+    public function getRpcResponse(): ?array
     {
         return $this->rpcResponses;
     }
 
-    public function getSuccessRpc()
+    /**
+     * 回傳解構後RPC Response 
+     * 內部包裹success case的RPC Response物件
+     * 如傳入rpcId 則回傳單一 RPC Response
+     *
+     * @param string|null $rpcId
+     * @return array|null|\Datto\JsonRpc\Responses\ResultResponse
+     */
+    public function getSuccessRpc(?string $rpcId = null)
     {
+        if (!is_null($rpcId)) {
+            return $this->rpcResponses["success"][$rpcId] ?? null;
+        }
         return $this->getRpcResponse()["success"] ?? null;
     }
 
-    public function getErrorRpc()
+    /**
+     * 回傳解構後RPC Response 
+     * 內部包裹error case的RPC Response物件
+     * 如傳入rpcId 則回傳單一 RPC Response
+     *
+     * @param string|null $rpcId
+     * @return array|null|\Datto\JsonRpc\Responses\ErrorResponse
+     */
+    public function getErrorRpc(?string $rpcId = null)
     {
+        if (!is_null($rpcId)) {
+            return $this->rpcResponses["error"][$rpcId] ?? null;
+        }
         return $this->getRpcResponse()["error"] ?? null;
     }
 

--- a/src/Service/Action.php
+++ b/src/Service/Action.php
@@ -144,11 +144,33 @@ class Action implements ActionInterface
      */
     protected $rpcRequest = null;
 
+    /**
+     * 是否啟用JSONRPC請求
+     *
+     * @var boolean
+     */
+    protected $isSetRpcRequest = false;
+
+    /**
+     * JSONRPC 響應
+     *
+     * @var array
+     */
+    protected $rpcResponses = null;
+
+    /**
+     * RPC Client
+     *
+     * @var \Datto\JsonRpc\Client
+     */
+    protected $rpcClient = null;
+
     public function __construct(string $serviceName, string $method, string $path)
     {
         $this->serviceName = $serviceName;
         $this->method = $method;
         $this->path = $path;
+        $this->rpcClient = new \Datto\JsonRpc\Client();
 
         if (is_null(ServiceList::getServiceData($this->serviceName))) {
             throw ActionException::forServiceDataNotFound($this->serviceName);
@@ -253,13 +275,14 @@ class Action implements ActionInterface
             $this->baseUrl . $this->getRequestPath(),
             $options
         )->then(
-            function (ResponseInterface $res) use (&$runtimeAction) {
+            function (ResponseInterface $res) use (&$runtimeAction, $alias) {
                 $runtimeAction->addNumOfActionDo();
+                
                 try {
                     // 將原本的setActionResponse放至verifyResponse呼叫
                     $runtimeAction->verifyResponse($res);
                 } catch (ActionException $th) {
-                    return $runtimeAction->processFailHandlerForRpc($th);
+                    return $runtimeAction->processFailHandlerForRpc($th ,$alias);
                 }
                 //執行後濾器
                 $runtimeAction->useFilters(false);
@@ -365,7 +388,7 @@ class Action implements ActionInterface
     {
         if ($th instanceof \GuzzleHttp\Exception\ConnectException) {
             $this->setActionResponse(null, false);
-            $exception = ActionException::forServiceActionConnectError($this->serviceName, $this->getRequestSetting(), $th->getRequest(), $this, $alias, $th->getMessage());
+            $exception = ActionException::forServiceActionConnectError($this->serviceName, $this->getRequestSetting(), $th->getRequest(), $this, $alias, $th->getMessage(),$this->rpcResponses);
             if (is_callable($this->failHandler)) {
                 call_user_func($this->failHandler, $exception);
             } else {
@@ -373,7 +396,7 @@ class Action implements ActionInterface
             }    
         }else if($th instanceof \GuzzleHttp\Exception\BadResponseException){
             $this->setActionResponse($th->getResponse(), false);
-            $exception = ActionException::forServiceActionFailError($this->serviceName, $this->getRequestSetting(), $th->getResponse(), $th->getRequest(), $this, $alias);
+            $exception = ActionException::forServiceActionFailError($this->serviceName, $this->getRequestSetting(), $th->getResponse(), $th->getRequest(), $this, $alias, $this->rpcResponses);
             if (is_callable($this->failHandler)) {
                 $this->response = $th->getResponse();
                 call_user_func($this->failHandler, $exception);
@@ -386,7 +409,7 @@ class Action implements ActionInterface
     public function processFailHandlerForRpc(ActionException $th,?string $alias = null)
     {
         $this->setActionResponse($this->response, false);
-        $exception = ActionException::forRpcResponseError($this->serviceName, $this->getRequestSetting(), $this, $alias, $th->getMessage());
+        $exception = ActionException::forRpcResponseError($this->serviceName, $this->getRequestSetting(), $this, $alias, $this->rpcResponses);
         if (is_callable($this->failHandler)) {
             call_user_func($this->failHandler, $exception);
         } else {
@@ -516,8 +539,9 @@ class Action implements ActionInterface
         }
 
         // 如果rpc請求存在，則加入body
-        if (!is_null($this->getRpcRequest())) {
-            $finallyOptions["body"] = $this->getRpcRequest();
+        if ($this->isSetRpcRequest && is_null($this->getRpcRequest())) {
+            $this->rpcRequest = $this->rpcClient->encode();
+            $finallyOptions["body"] = $this->rpcRequest;
             $this->method = "POST";
         }
         
@@ -719,12 +743,11 @@ class Action implements ActionInterface
      *
      * @param string|null $method
      * @param array $arguments
+     * @param string|null $id
      * @return ActionInterface
      */
     public function setRpcQuery(string $method = null, array $arguments = [], ?string $id = null): ActionInterface
     {
-        $rpcClient = ServiceList::getRpcClient();
-
         // the rpc unique id
         if (is_null($id)) {
             $id = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
@@ -735,11 +758,40 @@ class Action implements ActionInterface
             mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
           );
         }
+        $this->rpcClient->query($id, $method, $arguments);
+        $this->isSetRpcRequest = true;
 
-        $rpcClient->query($id, $method, $arguments);
+        return $this;
+    }
 
-        $this->rpcRequest = $rpcClient->encode();
+    /**
+     * 設定JSON RPC Batch呼叫參數
+     * 陣列規範 
+     * [
+     *   [method,[arguments],id],
+     *   [method,[arguments],id],
+     * ]
+     *
+     * @param array $batchRpcQuery
+     * 
+     * @return ActionInterface
+     */
+    public function setBatchRpcQuery(array $batchRpcQuery): ActionInterface
+    {
+        if (count($batchRpcQuery) == 0 | empty($batchRpcQuery)) {
+            throw  ActionException::forSetBatchRpcQueryBtDataNotExist($this->serviceName);
+        }
 
+        if (count($batchRpcQuery) == 1) {
+            $batchRpcQuery[0][2] = $batchRpcQuery[0][2] ?? null;
+            $this->setRpcQuery($batchRpcQuery[0][0],$batchRpcQuery[0][1], $batchRpcQuery[0][2]);
+        }else {
+            foreach ($batchRpcQuery as $rpcQuery) {
+                $rpcQuery[2] = $rpcQuery[2] ?? null;
+                $this->setRpcQuery($rpcQuery[0], $rpcQuery[1], $rpcQuery[2]);
+            }
+        }
+        $this->isSetRpcRequest = true;
         return $this;
     }
 
@@ -761,13 +813,72 @@ class Action implements ActionInterface
     public function verifyResponse(ResponseInterface $response)
     {
         if (!is_null($this->getRpcRequest())) {
-            $result = ServiceList::getRpcClient()->decode($response->getBody())[0];
-            if($result instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+            $rpcResults = $this->rpcClient->decode($response->getBody());
+            if (!is_array($rpcResults)) {
                 $this->setActionResponse($response,false);
-                throw ActionException::forRpcResponseErrorType($result->getMessage(), $result->getCode());
+                throw  ActionException::forRpcInvalidResponse($this->serviceName);
             }
+
+            foreach ($rpcResults as $rpcResponse) {
+                if ($rpcResponse instanceof \Datto\JsonRpc\Responses\ResultResponse) {
+                    $this->rpcResponses["success"][] = $rpcResponse;
+                } elseif ($rpcResponse instanceof \Datto\JsonRpc\Responses\ErrorResponse) {
+                    $this->rpcResponses["error"][] = $rpcResponse;
+                }
+            }
+            if (!empty($this->rpcResponses["error"])) {
+                $this->setActionResponse($response,false);
+                throw ActionException::forRpcResponseErrorType($this->serviceName);
+            }
+
         }
+        // 無使用RPC的請求或成功的RPC請求則從此執行
         $this->setActionResponse($response,true);
         return ;
+    }
+
+    /**
+     * 取得RPC響應實體
+     * 只回傳success的RPC響應
+     *
+     * @return array<\Datto\JsonRpc\Responses\Response>|null
+     */
+    public function getRpcResponse(): ?array
+    {
+        return $this->rpcResponses["success"] ?? null;
+    }
+
+    /**
+     * 取得RPC Result
+     *
+     * @return array<mixed>|null
+     */
+    public function getRpcResult(): ?array
+    {
+        if (!is_null($this->getRpcResponse())) {
+            $result = [];
+            foreach ($this->getRpcResponse() as $rpcRequest) {
+                $result[] =  $rpcRequest->getValue();
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * 取得RPC id
+     *
+     * @return array<string>|null
+     */
+    public function getRpcId(): ?array
+    {
+        if (!is_null($this->getRpcResponse())) {
+            $result = [];
+            foreach ($this->getRpcResponse() as $rpcResponse) {
+                $result[] =  $rpcResponse->getId();
+            }
+            return $result;
+        }
+        return null;
     }
 }

--- a/src/Service/ActionInterface.php
+++ b/src/Service/ActionInterface.php
@@ -249,6 +249,20 @@ interface ActionInterface
     public function setRpcQuery(string $method = null, array $arguments = [], ?string $id = null): ActionInterface;
 
     /**
+     * 設定JSON RPC Batch呼叫參數
+     * 陣列規範 
+     * [
+     *   [method,[arguments],id],
+     *   [method,[arguments],id],
+     * ]
+     *
+     * @param array $batchRpcQuery
+     * 
+     * @return ActionInterface
+     */
+    public function setBatchRpcQuery(array $batchRpcQuery): ActionInterface;
+
+    /**
      * 取得當前RPC請求json
      *
      * @return ?string
@@ -256,10 +270,23 @@ interface ActionInterface
     public function getRpcRequest(): ?string;
 
     /**
-     * 判斷Response是否為RPC Response，並解析是否有錯誤
-     *
-     * @param ResponseInterface $response
+     * 取得RPC響應實體
+     * 只回傳success的RPC響應
+     * @param string|null $rpcId
+     * 
+     * @return array<\Datto\JsonRpc\Responses\ResultResponse>|\Datto\JsonRpc\Responses\ResultResponse|null
      */
-    public function verifyResponse(ResponseInterface $response);
+    public function getRpcResponse(?string $rpcId = null): array | \Datto\JsonRpc\Responses\ResultResponse | null;
+
+    /**
+     * 取得RPC Result
+     * 若無傳入rpcId進行查詢則回傳將以RPC ID作為key，RPC result作為value形式回傳
+     * 若傳入rpcId則直接回傳result
+     * 
+     * @param string|null $rpcId
+     * 
+     * @return array<string<mixed>>|mixed|null
+     */
+    public function getRpcResult(?string $rpcId = null);
 
 }

--- a/src/Service/ActionInterface.php
+++ b/src/Service/ActionInterface.php
@@ -243,9 +243,10 @@ interface ActionInterface
      *
      * @param string|null $method
      * @param array $arguments
+     * @param string|null $id
      * @return ActionInterface
      */
-    public function setRpcQuery(string $method = null, array $arguments = []): ActionInterface;
+    public function setRpcQuery(string $method = null, array $arguments = [], ?string $id = null): ActionInterface;
 
     /**
      * 取得當前RPC請求json


### PR DESCRIPTION
**Description**
Changed scope: 
1. Add the batch rpc request method into `Action`.
2. Changed the way `rpcClient` is called because `rpcClient` was handling `ConcurrentAction` with RPC request obfuscation.
3. Changed `ActionException` logic for `RPC` error.
4. Deleted some error handle method in  `ActionException`.
5. Add new error handle method in  `ActionException`.
6. Changed the README.md and README_zh-TW.md


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide